### PR TITLE
Add ability to add listeners without using inline scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+##[v0.1.1] - 2024-03-02
+
+### Added
+- Add component and callback registry
+- Add support for registering event handlers via attributes
+
+### Changed
+- Split into more modules
+- Use `npm link` to use local `@aegisjsproejct/styles` & `@aegisjsproject/component`
+- Provide individual parsers via own modules
+
+### Fixed
+- Allow `shadowrootmode` instead of `shadowroot`
+
 ## [v0.1.0] - 2024-02-27
 
 ### Changed

--- a/callbackRegistry.js
+++ b/callbackRegistry.js
@@ -1,0 +1,87 @@
+let isRegistrationOpen = true;
+
+export const closeRegistration = () => isRegistrationOpen = false;
+
+export const FUNCS = {
+	debug: {
+		log: 'aegis:debug:log',
+		info: 'aegis:debug:info',
+		warn: 'aegis:debug:warn',
+		error: 'aegis:debug:error',
+	},
+	navigate: {
+		back: 'aegis:navigate:back',
+		forward: 'aegis:navigate:forward',
+		reload: 'aegis:navigate:reload',
+		link: 'aegis:navigate:go',
+	},
+	print: 'aegis:print',
+};
+
+const handlers = new Map([
+	[FUNCS.debuglog, console.log],
+	[FUNCS.debug.warn, console.warn],
+	[FUNCS.debug.error, console.error],
+	[FUNCS.debug.info, console.info],
+	[FUNCS.navigate.back, () => history.back()],
+	[FUNCS.navigate.forward, () => history.forward()],
+	[FUNCS.navigate.reload, () => location.reload()],
+	[FUNCS.navigate.link, event => {
+		if (event.isTrusted) {
+			event.preventDefault();
+			location.href = event.currentTarget.href;
+		}
+	}],
+	[FUNCS.print, () => globalThis.print()],
+]);
+
+
+export const listCallbacks = () => Array.from(handlers.keys());
+
+export const hasCallback = name => handlers.has(name);
+
+export const getCallback = name => handlers.get(name);
+
+export function callCallback(name, ...args) {
+	if (handlers.has(name)) {
+		return handlers.get(name).apply(this || globalThis, args);
+	} else {
+		throw new Error(`No ${name} function registered.`);
+	}
+}
+
+export function createCallback(callback) {
+	const name = [
+		Date.now().toString(16),
+		...Array.from(crypto.getRandomValues(new Uint8Array(3))).map(i => i.toString(16))
+	].join(':');
+
+	return registerCallback(name, callback);
+}
+
+export function registerCallback(name, callback) {
+	if (typeof name !==  'string' || name.length === 0) {
+		throw new TypeError('Callback name must be a string.');
+	} if (! (callback instanceof Function)) {
+		throw new TypeError('Callback must be a function.');
+	} else if (isRegistrationOpen) {
+		if (handlers.has(name)) {
+			throw new Error(`Handler "${name}" is already registered.`);
+		} else {
+			handlers.set(name, callback);
+			return name;
+		}
+	}
+}
+
+export function getHost(target) {
+	if (target instanceof Event) {
+		return getHost(target.currentTarget);
+	} else if (target instanceof Document) {
+		return target;
+	} else if (target instanceof Element) {
+		return getHost(target.getRootNode());
+	} else if (target instanceof ShadowRoot) {
+		return target.host;
+	}
+}

--- a/componentRegistry.js
+++ b/componentRegistry.js
@@ -1,0 +1,19 @@
+const registry = new Set();
+
+export function registerComponent(tag, constructor, opts) {
+	if (registry.has(tag)) {
+		throw new Error(`<${tag}> is already registered.`);
+	} else {
+		customElements.define(tag, constructor, opts);
+		registry.add(tag);
+		return constructor;
+	}
+}
+
+export function getRegisteredComponentTags() {
+	return Object.freeze(Array.from(registry));
+}
+
+export function getRegisteredComponents() {
+	return Object.freeze(Array.from(registry, tag => customElements.get(tag)));
+}

--- a/dom.js
+++ b/dom.js
@@ -1,0 +1,88 @@
+import { attachListeners } from './events.js';
+
+export const getUniqueSelector = (prefix = '_aegis-scope') => `${prefix}-${crypto.randomUUID()}`;
+
+export function replaceStyles(target, ...sheets) {
+	if (! (target instanceof Node)) {
+		throw new TypeError('Expected target to be a Document, DocumentFragment, ShadowRoot, or Element.');
+	} else if (target instanceof Document || target instanceof ShadowRoot) {
+		target.adoptedStyleSheets = sheets;
+	} else if (! (target instanceof Element || DocumentFragment)) {
+		throw new TypeError('Expected target to be a Document, DocumentFragment, ShadowRoot, or Element.');
+	} else if (target.shadowRoot instanceof ShadowRoot) {
+		return replaceStyles(target.shadowRoot, ...sheets);
+	} else if (! target.isConnected) {
+		throw new TypeError('Target is not connected to the document yet.');
+	} else {
+		return replaceStyles(target.getRootNode({ composed: false }), ...sheets);
+	}
+}
+
+export function addStyles(target, ...sheets) {
+	if (! (target instanceof Node)) {
+		throw new TypeError('Expected target to be a Document, DocumentFragment, ShadowRoot, or Element.');
+	} else if (target instanceof Document || target instanceof ShadowRoot) {
+		replaceStyles(target, ...target.adoptedStyleSheets, ...sheets);
+	} else if (target.shadowRoot instanceof ShadowRoot) {
+		return addStyles(target.shadowRoot, ...sheets);
+	} else {
+		return addStyles(target.getRootNode({ composed: false }), ...sheets);
+	}
+}
+
+export function appendTo(target, ...items) {
+	if (! (target instanceof Node)) {
+		throw new TypeError('Target must be a Node.');
+	} else {
+		const styles = items.filter(item => item instanceof CSSStyleSheet);
+		const children = items.filter(item => typeof item === 'string' || item instanceof Node);
+
+		if (styles.length !== 0) {
+			addStyles(target, ...styles);
+		}
+
+		if (children.length !== 0) {
+			target.append(...children);
+		}
+
+		attachListeners(target instanceof ShadowRoot ? target.host : target);
+	}
+}
+
+export function prependTo(target, ...items) {
+	if (! (target instanceof Node)) {
+		throw new TypeError('Target must be a Node.');
+	} else {
+		const styles = items.filter(item => item instanceof CSSStyleSheet);
+		const children = items.filter(item => typeof item === 'string' || item instanceof Node);
+
+		if (styles.length !== 0) {
+			addStyles(target, ...styles);
+		}
+
+		if (children.length !== 0) {
+			target.prepend(...children);
+		}
+
+		attachListeners(target instanceof ShadowRoot ? target.host : target);
+	}
+}
+
+export function replace(target, ...items) {
+	if (! (target instanceof Node)) {
+		throw new TypeError('Target must be a Node.');
+	} else {
+		const styles = items.filter(item => item instanceof CSSStyleSheet);
+		const children = items.filter(item => typeof item === 'string' || item instanceof Node);
+
+		if (styles.length !== 0) {
+			replaceStyles(target, ...styles);
+		}
+
+		if (children.length !== 0) {
+			target.replaceChildren(...children);
+		}
+
+		attachListeners(target instanceof ShadowRoot ? target.host : target);
+	}
+}

--- a/events.js
+++ b/events.js
@@ -1,0 +1,45 @@
+import { eventAttrs, EVENT_PREFIX_LENGTH } from './sanitizerConfig.js';
+import { hasCallback, getCallback } from './callbackRegistry.js';
+
+export const AEGIS_EVENT_HANDLER_CLASS = '_aegis-event-handler';
+
+export const EVENTS = Object.fromEntries(eventAttrs.map(attr => [
+	`on${attr[EVENT_PREFIX_LENGTH].toUpperCase() + attr.substring(EVENT_PREFIX_LENGTH + 1)}`,
+	attr
+]));
+
+export function attachListeners(target, { signal } = {}) {
+	target.querySelectorAll(`.${AEGIS_EVENT_HANDLER_CLASS}`).forEach(el => {
+		for (const attr of el.getAttributeNames().filter(name => eventAttrs.includes(name))) {
+			const val = el.getAttribute(attr);
+
+			try {
+				if (typeof val === 'string' && val.length !== 0 && hasCallback(val)) {
+					const event = attr.substring(EVENT_PREFIX_LENGTH).trim();
+					const callback = getCallback(val);
+					const passive = el.hasAttribute('aegis:event:passive');
+					const capture = el.hasAttribute('aegis:event:capture');
+					const once = el.hasAttribute('aegis:event:once');
+					el.addEventListener(event, callback, { passive, capture, once, signal });
+				} else {
+					console.warn(`No handler registered for ${val}`);
+				}
+			} catch(err) {
+				console.error(err);
+			} finally {
+				el.removeAttribute(attr);
+				el.removeAttribute('aegis:event:passive');
+				el.removeAttribute('aegis:event:capture');
+				el.removeAttribute('aegis:event:once');
+
+				if (el.classList.length === 1) {
+					el.removeAttribute('class');
+				} else {
+					el.classList.remove(AEGIS_EVENT_HANDLER_CLASS);
+				}
+			}
+		}
+	});
+
+	return target;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "funding": [
         {
           "type": "librepay",
@@ -19,8 +19,65 @@
       ],
       "license": "MIT",
       "devDependencies": {
-        "@shgysk8zer0/aegis-component": "^0.0.4",
-        "@shgysk8zer0/aegis-styles": "^0.0.3",
+        "@aegisjsproject/component": "file:../component",
+        "@aegisjsproject/styles": "file:../styles",
+        "eslint": "^8.56.0",
+        "http-server": "^14.1.1",
+        "rollup": "^4.9.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../component": {
+      "name": "@aegisjsproject/component",
+      "version": "0.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "librepay",
+          "url": "https://liberapay.com/shgysk8zer0"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/shgysk8zer0"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@aegisjsproject/core": "^0.1.0",
+        "@aegisjsproject/styles": "^0.1.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "eslint": "^8.56.0",
+        "http-server": "^14.1.1",
+        "rollup": "^4.9.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../styles": {
+      "name": "@aegisjsproject/styles",
+      "version": "0.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "librepay",
+          "url": "https://liberapay.com/shgysk8zer0"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/shgysk8zer0"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@aegisjsproject/core": "^0.1.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^15.2.3",
         "eslint": "^8.56.0",
         "http-server": "^14.1.1",
         "rollup": "^4.9.6"
@@ -37,6 +94,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@aegisjsproject/component": {
+      "resolved": "../component",
+      "link": true
+    },
+    "node_modules/@aegisjsproject/styles": {
+      "resolved": "../styles",
+      "link": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -330,89 +395,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@shgysk8zer0/aegis": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/aegis/-/aegis-0.0.5.tgz",
-      "integrity": "sha512-ub/tylq6Bjw9mIMtPq732g0DeLzZhWEPgw+VAgRi7T9iF0d9/YWCC2YCcmuSDsQ3p+8V0yJBug+eQr49Br0zcw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "librepay",
-          "url": "https://liberapay.com/shgysk8zer0"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/shgysk8zer0"
-        }
-      ],
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@shgysk8zer0/aegis-component": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/aegis-component/-/aegis-component-0.0.4.tgz",
-      "integrity": "sha512-BF7DnBlvC/9GS8juVQSsqOqxymwkBm1oSWtOo611/9AWNG4VTJb+Lh7g+OEUJQ35kG9pv+8NwFf3biiBzG2EMw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "librepay",
-          "url": "https://liberapay.com/shgysk8zer0"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/shgysk8zer0"
-        }
-      ],
-      "dependencies": {
-        "@shgysk8zer0/aegis": "^0.0.8",
-        "@shgysk8zer0/aegis-styles": "^0.0.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@shgysk8zer0/aegis-component/node_modules/@shgysk8zer0/aegis": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/aegis/-/aegis-0.0.8.tgz",
-      "integrity": "sha512-ojTxb0kKgkdbTJvV7g/IiSB1IaOw9hMrWR3Ifp66xat5mi6lkQAZXX75YmxhciXGMoH7gqMMH1DDafNh4j2S2g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "librepay",
-          "url": "https://liberapay.com/shgysk8zer0"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/shgysk8zer0"
-        }
-      ],
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@shgysk8zer0/aegis-styles": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/aegis-styles/-/aegis-styles-0.0.3.tgz",
-      "integrity": "sha512-G76vedCL4ZyQSF++B0EbqOkNNyWPeB1wAiqtS6pGOVdH8y4ms4Wtg6Cew0mlMCnYX3HqF4ABEsZR5vXANKTQrQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "librepay",
-          "url": "https://liberapay.com/shgysk8zer0"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/shgysk8zer0"
-        }
-      ],
-      "dependencies": {
-        "@shgysk8zer0/aegis": "^0.0.5"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -1874,6 +1856,27 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
+    "@aegisjsproject/component": {
+      "version": "file:../component",
+      "requires": {
+        "@aegisjsproject/core": "^0.1.0",
+        "@aegisjsproject/styles": "^0.1.0",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "eslint": "^8.56.0",
+        "http-server": "^14.1.1",
+        "rollup": "^4.9.6"
+      }
+    },
+    "@aegisjsproject/styles": {
+      "version": "file:../styles",
+      "requires": {
+        "@aegisjsproject/core": "^0.1.0",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "eslint": "^8.56.0",
+        "http-server": "^14.1.1",
+        "rollup": "^4.9.6"
+      }
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2051,39 +2054,6 @@
       "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
       "dev": true,
       "optional": true
-    },
-    "@shgysk8zer0/aegis": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/aegis/-/aegis-0.0.5.tgz",
-      "integrity": "sha512-ub/tylq6Bjw9mIMtPq732g0DeLzZhWEPgw+VAgRi7T9iF0d9/YWCC2YCcmuSDsQ3p+8V0yJBug+eQr49Br0zcw==",
-      "dev": true
-    },
-    "@shgysk8zer0/aegis-component": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/aegis-component/-/aegis-component-0.0.4.tgz",
-      "integrity": "sha512-BF7DnBlvC/9GS8juVQSsqOqxymwkBm1oSWtOo611/9AWNG4VTJb+Lh7g+OEUJQ35kG9pv+8NwFf3biiBzG2EMw==",
-      "dev": true,
-      "requires": {
-        "@shgysk8zer0/aegis": "^0.0.8",
-        "@shgysk8zer0/aegis-styles": "^0.0.3"
-      },
-      "dependencies": {
-        "@shgysk8zer0/aegis": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/@shgysk8zer0/aegis/-/aegis-0.0.8.tgz",
-          "integrity": "sha512-ojTxb0kKgkdbTJvV7g/IiSB1IaOw9hMrWR3Ifp66xat5mi6lkQAZXX75YmxhciXGMoH7gqMMH1DDafNh4j2S2g==",
-          "dev": true
-        }
-      }
-    },
-    "@shgysk8zer0/aegis-styles": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/aegis-styles/-/aegis-styles-0.0.3.tgz",
-      "integrity": "sha512-G76vedCL4ZyQSF++B0EbqOkNNyWPeB1wAiqtS6pGOVdH8y4ms4Wtg6Cew0mlMCnYX3HqF4ABEsZR5vXANKTQrQ==",
-      "dev": true,
-      "requires": {
-        "@shgysk8zer0/aegis": "^0.0.5"
-      }
     },
     "@types/estree": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A fast, secure, modern, light-weight, and simple JS library for creating web components and more!",
   "keywords": [
     "aegis",
@@ -90,8 +90,8 @@
   },
   "homepage": "https://github.com/AegisJSProject/core#readme",
   "devDependencies": {
-    "@shgysk8zer0/aegis-component": "^0.0.4",
-    "@shgysk8zer0/aegis-styles": "^0.0.3",
+    "@aegisjsproject/component": "file:../component",
+    "@aegisjsproject/styles": "file:../styles",
     "eslint": "^8.56.0",
     "http-server": "^14.1.1",
     "rollup": "^4.9.6"

--- a/parsers.js
+++ b/parsers.js
@@ -1,0 +1,6 @@
+export { text } from './parsers/text.js';
+export { createStyleSheet, createCSSParser, css, lightCSS, darkCSS } from './parsers/css.js';
+export { sanitizeString, createHTMLParser, html } from './parsers/html.js';
+export { xml } from './parsers/xml.js';
+export { svg } from './parsers/svg.js';
+export { json } from './parsers/json.js';

--- a/parsers/css.js
+++ b/parsers/css.js
@@ -1,0 +1,20 @@
+export function createStyleSheet(rules, { media, disabled, baseURL } = {}) {
+	if (media instanceof MediaQueryList) {
+		return createStyleSheet(rules, { media: media.media, disabled, baseURL });
+	} else {
+		const sheet = new CSSStyleSheet({ media, disabled, baseURL });
+		sheet.replaceSync(rules);
+
+		return sheet;
+	}
+}
+
+export function createCSSParser({ media, disabled, baseURL } = {}) {
+	return (...args) => createStyleSheet(String.raw.apply(null, args), { media, disabled, baseURL });
+}
+
+export const css = createCSSParser({ baseURL: document.baseURI });
+
+export const lightCSS = createCSSParser({ media: '(prefers-color-scheme: light)', baseURL: document.baseURI });
+
+export const darkCSS = createCSSParser({ media: '(prefers-color-scheme: dark)', baseURL: document.baseURI });

--- a/parsers/html.js
+++ b/parsers/html.js
@@ -1,0 +1,38 @@
+import { stringify } from '../stringify.js';
+import * as sanitizerConfig from '../sanitizerConfig.js';
+
+export function sanitizeString(str, {
+	allowElements = sanitizerConfig.allowElements,
+	allowAttributes = sanitizerConfig.allowAttributes,
+	allowCustomElements = sanitizerConfig.allowCustomElements,
+	allowUnknownMarkup = sanitizerConfig.allowUnknownMarkup,
+	allowComments = sanitizerConfig.allowComments,
+} = sanitizerConfig) {
+	const el = document.createElement('div');
+	const frag = document.createDocumentFragment();
+
+	el.setHTML(str, {
+		allowElements, allowAttributes, allowCustomElements,
+		allowUnknownMarkup, allowComments,
+	});
+
+	frag.append(...el.children);
+
+	return frag;
+}
+
+export function createHTMLParser({
+	allowElements = sanitizerConfig.allowElements,
+	allowAttributes = sanitizerConfig.allowAttributes,
+	allowCustomElements = sanitizerConfig.allowCustomElements,
+	allowUnknownMarkup = sanitizerConfig.allowUnknownMarkup,
+	allowComments = sanitizerConfig.allowComments,
+	...rest
+} = sanitizerConfig) {
+	return (strings, ...values) => sanitizeString(String.raw(strings, ...values.map(stringify)), {
+		allowElements, allowAttributes, allowCustomElements,
+		allowUnknownMarkup, allowComments, ...rest,
+	});
+}
+
+export const html = createHTMLParser(sanitizerConfig);

--- a/parsers/json.js
+++ b/parsers/json.js
@@ -1,0 +1,1 @@
+export const json = (...args) => JSON.parse(String.raw.apply(null, args));

--- a/parsers/svg.js
+++ b/parsers/svg.js
@@ -1,0 +1,13 @@
+import { stringify } from '../stringify.js';
+
+export const svg = (strings, ...values) => {
+	const parsedStr = String.raw(strings, ...values.map(stringify));
+
+	// Check for xmlns on <svg>
+	if (! parsedStr.match(/^\s*<svg\s[^>]*xmlns="http:\/\/www\.w3\.org\/2000\/svg"/)) {
+		// Add xmlns to the root SVG element
+		return svg({ raw: [parsedStr.replace(/^\s*<svg\s+/, '<svg xmlns="http://www.w3.org/2000/svg" ')] });
+	} else {
+		return new DOMParser().parseFromString(parsedStr, 'image/svg+xml').documentElement;
+	}
+};

--- a/parsers/text.js
+++ b/parsers/text.js
@@ -1,0 +1,5 @@
+import { stringify } from '../stringify.js';
+
+export const text = (strings, ...values) => Array.isArray(strings) && Array.isArray(strings.raw)
+	? String.raw(strings, ...values.map(stringify))
+	: String.raw({ raw: Array.isArray(strings) ? strings : [strings] }, ...values.map(stringify));

--- a/parsers/xml.js
+++ b/parsers/xml.js
@@ -1,0 +1,4 @@
+import { stringify } from '../stringify.js';
+
+export const xml = (strings, ...values) => new DOMParser()
+	.parseFromString(String.raw(strings, ...values.map(stringify)), 'application/xml');

--- a/sanitizerConfig.js
+++ b/sanitizerConfig.js
@@ -3,6 +3,46 @@
  * @see https://wicg.github.io/sanitizer-api/#default-configuration-dictionary
  */
 
+export const EVENT_PREFIX =  'aegis:';
+export const EVENT_PREFIX_LENGTH = EVENT_PREFIX.length;
+
+export const eventAttrs = [
+	EVENT_PREFIX + 'abort', EVENT_PREFIX + 'blur', EVENT_PREFIX + 'focus',
+	EVENT_PREFIX + 'cancel', EVENT_PREFIX + 'auxclick', EVENT_PREFIX + 'beforeinput',
+	EVENT_PREFIX + 'beforetoggle', EVENT_PREFIX + 'canplay', EVENT_PREFIX + 'canplaythrough',
+	EVENT_PREFIX + 'change', EVENT_PREFIX + 'click', EVENT_PREFIX + 'close',
+	EVENT_PREFIX + 'contextmenu', EVENT_PREFIX + 'copy',  EVENT_PREFIX + 'cuechange',
+	EVENT_PREFIX + 'cut', EVENT_PREFIX + 'dblclick', EVENT_PREFIX + 'drag',
+	EVENT_PREFIX + 'dragend', EVENT_PREFIX + 'dragenter', EVENT_PREFIX + 'dragexit',
+	EVENT_PREFIX + 'dragleave', EVENT_PREFIX + 'dragover', EVENT_PREFIX + 'dragstart',
+	EVENT_PREFIX + 'drop', EVENT_PREFIX + 'durationchange', EVENT_PREFIX + 'emptied',
+	EVENT_PREFIX + 'ended', EVENT_PREFIX + 'formdata', EVENT_PREFIX + 'input',
+	EVENT_PREFIX + 'invalid', EVENT_PREFIX + 'keydown', EVENT_PREFIX + 'keypress',
+	EVENT_PREFIX + 'keyup', EVENT_PREFIX + 'load', EVENT_PREFIX + 'loadeddata',
+	EVENT_PREFIX + 'loadedmetadata', EVENT_PREFIX + 'loadstart', EVENT_PREFIX + 'mousedown',
+	EVENT_PREFIX + 'mouseenter', EVENT_PREFIX + 'mouseleave', EVENT_PREFIX + 'mousemove',
+	EVENT_PREFIX + 'mouseout', EVENT_PREFIX + 'mouseover', EVENT_PREFIX + 'mouseup',
+	EVENT_PREFIX + 'wheel', EVENT_PREFIX + 'paste', EVENT_PREFIX + 'pause',
+	EVENT_PREFIX + 'play', EVENT_PREFIX + 'playing', EVENT_PREFIX + 'progress',
+	EVENT_PREFIX + 'ratechange', EVENT_PREFIX + 'reset', EVENT_PREFIX + 'resize',
+	EVENT_PREFIX + 'scroll', EVENT_PREFIX + 'scrollend', EVENT_PREFIX + 'securitypolicyviolation',
+	EVENT_PREFIX + 'seeked', EVENT_PREFIX + 'seeking', EVENT_PREFIX + 'select',
+	EVENT_PREFIX + 'slotchange', EVENT_PREFIX + 'stalled', EVENT_PREFIX + 'submit',
+	EVENT_PREFIX + 'suspend', EVENT_PREFIX + 'timeupdate', EVENT_PREFIX + 'volumechange',
+	EVENT_PREFIX + 'waiting', EVENT_PREFIX + 'selectstart', EVENT_PREFIX + 'selectionchange',
+	EVENT_PREFIX + 'toggle', EVENT_PREFIX + 'pointercancel', EVENT_PREFIX + 'pointerdown',
+	EVENT_PREFIX + 'pointerup',  EVENT_PREFIX + 'pointermove', EVENT_PREFIX + 'pointerout',
+	EVENT_PREFIX + 'pointerover', EVENT_PREFIX + 'pointerenter', EVENT_PREFIX + 'pointerleave',
+	EVENT_PREFIX + 'gotpointercapture', EVENT_PREFIX + 'lostpointercapture',
+	EVENT_PREFIX + 'mozfullscreenchange', EVENT_PREFIX + 'mozfullscreenerror',
+	EVENT_PREFIX + 'animationcancel', EVENT_PREFIX + 'animationend', EVENT_PREFIX + 'animationiteration',
+	EVENT_PREFIX + 'animationstart', EVENT_PREFIX + 'transitioncancel',
+	EVENT_PREFIX + 'transitionend', EVENT_PREFIX + 'transitionrun', EVENT_PREFIX + 'transitionstart',
+	EVENT_PREFIX + 'webkitanimationend', EVENT_PREFIX + 'webkitanimationiteration',
+	EVENT_PREFIX + 'webkitanimationstart', EVENT_PREFIX + 'webkittransitionend',
+	EVENT_PREFIX + 'error',
+];
+
 export const allowCustomElements = true;
 export const allowUnknownMarkup = false;
 export const allowComments = false;
@@ -196,7 +236,7 @@ export const allowAttributes = {
 	'scrolling': ['*'],
 	'select': ['*'],
 	'selected': ['*'],
-	'shadowroot': ['*'],
+	'shadowrootmode': ['*'],
 	'shadowrootdelegatesfocus': ['*'],
 	'shape': ['*'],
 	'size': ['*'],
@@ -232,5 +272,14 @@ export const allowAttributes = {
 	'vspace': ['*'],
 	'webkitdirectory': ['*'],
 	'width': ['*'],
-	'wrap': ['*']
+	'wrap': ['*'],
+	'aegis:event:capture': ['*'],
+	'aegis:event:passive': ['*'],
+	'aegis:event:once': ['*'],
+	...Object.fromEntries(eventAttrs.map(attr => [attr, ['*']]))
+};
+
+export const sanitizerConfig = {
+	allowCustomElements, allowUnknownMarkup, allowComments, allowElements,
+	allowAttributes,
 };

--- a/stringify.js
+++ b/stringify.js
@@ -1,0 +1,60 @@
+export const DATE_FORMAT = {
+	weekday: 'short',
+	month: 'short',
+	day: 'numeric',
+	year: 'numeric',
+	hour: 'numeric',
+	minute: '2-digit',
+};
+
+export const formatDate = (date, {
+	weekday = DATE_FORMAT.weekday,
+	month = DATE_FORMAT.month,
+	day = DATE_FORMAT.day,
+	year = DATE_FORMAT.year,
+	hour = DATE_FORMAT.hour,
+	minute = DATE_FORMAT.minute,
+} = DATE_FORMAT) => date.toLocaleString(navigator.language, {
+	weekday, month, day, year, hour, minute,
+});
+
+const formatArray = 'Intl' in globalThis && Intl.ListFormat instanceof Function
+	? arr => new Intl.ListFormat().format(arr.map(stringify))
+	: arr => arr.join(', ');
+
+const formatNumber = 'Intl' in globalThis && Intl.NumberFormat instanceof Function
+	? num => new Intl.NumberFormat().format(num)
+	: num => num.toString();
+
+const formatEl = el => el.outerHTML;
+
+export const stringify = thing => {
+	switch(typeof thing) {
+		case 'string':
+			return thing;
+
+		case 'number':
+			return formatNumber(thing);
+
+		case 'object':
+			if (Array.isArray(thing)) {
+				return formatArray(thing);
+			} else if (thing instanceof Element) {
+				return formatEl(thing);
+			} else if(thing instanceof Date) {
+				return formatDate(thing);
+			} else if ('Iterator' in globalThis && thing instanceof globalThis.Iterator) {
+				return stringify([...thing]);
+			} else if (thing === null) {
+				return '';
+			} else {
+				return thing.toString();
+			}
+
+		case 'undefined':
+			return '';
+
+		default:
+			return thing.toString();
+	}
+};

--- a/test/index.html
+++ b/test/index.html
@@ -6,24 +6,21 @@
 		<meta name="color-scheme" content="light dark" />
 		<meta http-equiv="Content-Security-Policy"
 			content="default-src 'none';
-			script-src 'self' https://unpkg.com/@shgysk8zer0/ https://unpkg.com/@aegisjsproject/ 'sha384-z00C+r/e+I1mYMOID0+ivQIyrVhwtoXQZ75ohGBL1hgHzznjQSR4Rg0l4jQp22H4';
+			script-src 'self' https://unpkg.com/@shgysk8zer0/ https://unpkg.com/@aegisjsproject/ 'sha384-z00C+r/e+I1mYMOID0+ivQIyrVhwtoXQZ75ohGBL1hgHzznjQSR4Rg0l4jQp22H4' 'nonce-dfgdfhjg';
 			style-src 'self' blob: data:;
 			connect-src https://icanhazdadjoke.com https://unpkg.com/@shgysk8zer0/ https://unpkg.com/@kernvalley/;
 			trusted-types empty#html empty#script sanitizer-raw#html default;
 			require-trusted-types-for 'script';" />
 		<title>Aegis Test</title>
-		<script type="importmap" integrity="sha384-z00C+r/e+I1mYMOID0+ivQIyrVhwtoXQZ75ohGBL1hgHzznjQSR4Rg0l4jQp22H4">
+		<script type="importmap" nonce="dfgdfhjg" integrity="sha384-z00C+r/e+I1mYMOID0+ivQIyrVhwtoXQZ75ohGBL1hgHzznjQSR4Rg0l4jQp22H4">
 			{
 				"imports": {
 					"@aegisjsproject/core": "../core.js",
-					"@shgysk8zer0/aegis": "../core.js",
 					"@aegisjsproject/core/": "../",
-					"@shgysk8zer0/aegis/": "../",
-					"@shgysk8zer0/aegis/aegis.js": "../core.js",
-					"@shgysk8zer0/aegis-styles": "../node_modules/@shgysk8zer0/aegis-styles/styles.js",
-					"@shgysk8zer0/aegis-styles/": "../node_modules/@shgysk8zer0/aegis-styles/",
-					"@shgysk8zer0/aegis-component": "../node_modules/@shgysk8zer0/aegis-component/component.js",
-					"@shgysk8zer0/aegis-component/": "../node_modules/@shgyk8zer0/aegis-component/",
+					"@aegisjsproject/styles": "../node_modules/@aegisjsproject/styles/styles.js",
+					"@aegisjsproject/styles/": "../node_modules/@aegisjsproject/styles/",
+					"@aegisjsproject/component": "../node_modules/@aegisjsproject/component/component.js",
+					"@aegisjsproject/component/": "../node_modules/@aegisjsproject/component/",
 					"@shgysk8zer0/": "https://unpkg.com/@shgysk8zer0/",
 					"@kernvalley/": "https://unpkg.com/@kernvalley/"
 				}

--- a/test/index.js
+++ b/test/index.js
@@ -1,14 +1,15 @@
-import { html, css, replaceStyles, getUniqueSelector, createPolicy } from '@aegisjsproject/core';
-import { reset } from '@shgysk8zer0/aegis-styles/reset.js';
-import { baseTheme, lightTheme, darkTheme } from '@shgysk8zer0/aegis-styles/theme.js';
-import { getComponent } from '@shgysk8zer0/aegis-component';
+import {
+	html, css, replaceStyles, getUniqueSelector, createPolicy, appendTo,
+	createCallback, EVENTS, AEGIS_EVENT_HANDLER_CLASS, FUNCS,
+} from '@aegisjsproject/core';
+import { reset } from '@aegisjsproject/styles/reset.js';
+import { baseTheme, lightTheme, darkTheme } from '@aegisjsproject/styles/theme.js';
 import './dad-joke.js';
 
 createPolicy('default', {
-	createHTML: (input, ...args) => {
+	createHTML: (input) => {
 		const el = document.createElement(input);
 		el.setHTML(input);
-		console.log({ input, args });
 		return el.innerHTML;
 	},
 	createScript: () => trustedTypes.emptyScript,
@@ -20,11 +21,19 @@ replaceStyles(document, reset, baseTheme, lightTheme, darkTheme, css`.${scope} {
 	color: red;
 }`);
 
-const DadJoke = await getComponent('dad-joke');
+const DadJoke = await customElements.whenDefined('dad-joke');
 
-document.body.append(
-	html`<header>
+appendTo(document.body, html`
+	<header>
 		<h1 class="${scope}">Hello, World!</h1>
 	</header>`,
-	new DadJoke(),
-);
+new DadJoke(),
+html`
+	<button href="./#foo" ${EVENTS.onClick}="${FUNCS.navigate.link}" class="${AEGIS_EVENT_HANDLER_CLASS}">Link</button>
+	<button type="button" ${EVENTS.onClick}="${createCallback(() => alert('Testing!'))}" class="${AEGIS_EVENT_HANDLER_CLASS}">TEST</button>
+	<button type="button" ${EVENTS.onClick}="${FUNCS.debug.log}" data-foo="bar" class="${AEGIS_EVENT_HANDLER_CLASS} btn btn-primary">Log</button>
+	<button type="button" ${EVENTS.onClick}="${FUNCS.navigate.back}" class="${AEGIS_EVENT_HANDLER_CLASS} btn  btn-primary">Back</button>
+	<button type="button" ${EVENTS.onClick}="${FUNCS.navigate.forward}" class="${AEGIS_EVENT_HANDLER_CLASS} btn  btn-primary">Forward</button>
+	<button type="button" ${EVENTS.onClick}="${FUNCS.navigate.reload}" class="${AEGIS_EVENT_HANDLER_CLASS} btn  btn-primary">Reload</button>
+	<button type="button" ${EVENTS.onClick}="${FUNCS.print}" class="${AEGIS_EVENT_HANDLER_CLASS} btn btn-primary">Print</button>
+`);


### PR DESCRIPTION
**Added**
- Add component and callback registry
- Add support for registering event handlers via attributes

**Changed**
- Split into more modules
- Use `npm link` to use local `@aegisjsproejct/styles` &
`@aegisjsproject/component`
- Provide individual parsers via own modules

**Fixed**
- Allow `shadowrootmode` instead of `shadowroot`

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
