### PR TITLE
Update event attributes and callback registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.1.4] - 2024-03-09
+
+### Added
+- Handle wider variety of objects (such as `HTMLTemplateElement` and `NodeList`, and even functions) in `stringify()`
+- Allow attributes for the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
+- Add more built-in callbacks to the callback registry
+- Add function to get registered component observed attributes by tag name
+
+### Changed
+- Refactor event handling
+- Do not remove other attributes when adding event listeners from callback registry
+- Update Polyfills version (allowing `data-*` attributes)
+
+### Removed
+- Remove `AEGIS_EVENT_HANDLER_CLASS`
+
 ## [v0.1.3] - 2024-03-05
 
 ### Added
 - Components registered via `registerComponent()` are now automatically allowed in sanitizer `allowElements`
-- Handle wider variety of objects (such as `HTMLTemplateElement` and `NodeList`) in `stringify()`
 
 ### Changed
 - Update `README.md` to be more accurate/current

--- a/callbackRegistry.js
+++ b/callbackRegistry.js
@@ -2,6 +2,10 @@ let isRegistrationOpen = true;
 
 export const closeRegistration = () => isRegistrationOpen = false;
 
+function $(selector, base = document) {
+	return base.querySelectorAll(selector);
+}
+
 export const FUNCS = {
 	debug: {
 		log: 'aegis:debug:log',
@@ -14,12 +18,26 @@ export const FUNCS = {
 		forward: 'aegis:navigate:forward',
 		reload: 'aegis:navigate:reload',
 		link: 'aegis:navigate:go',
+		popup: 'aegis:navigate:popup',
 	},
-	print: 'aegis:print',
+	ui: {
+		print: 'aegis:ui:print',
+		remove: 'aegis:ui:remove',
+		hide: 'aegis:ui:hide',
+		unhide: 'aegis:ui:unhide',
+		showModal: 'aegis:ui:showModal',
+		closeModal: 'aegis:ui:closeModal',
+		showPopover: 'aegis:ui:showPopover',
+		hidePopover: 'aegis:ui:hidePopover',
+		togglePopover: 'aegis:ui:togglePopover',
+		enable: 'aegis:ui:enable',
+		disable: 'aegis:ui:disable',
+		scrollTo: 'aegis:ui:scrollTo',
+	},
 };
 
 const handlers = new Map([
-	[FUNCS.debuglog, console.log],
+	[FUNCS.debug.log, console.log],
 	[FUNCS.debug.warn, console.warn],
 	[FUNCS.debug.error, console.error],
 	[FUNCS.debug.info, console.info],
@@ -29,12 +47,78 @@ const handlers = new Map([
 	[FUNCS.navigate.link, event => {
 		if (event.isTrusted) {
 			event.preventDefault();
-			location.href = event.currentTarget.href;
+			location.href = event.currentTarget.dataset.url;
 		}
 	}],
-	[FUNCS.print, () => globalThis.print()],
-]);
+	[FUNCS.navigate.popup, event => {
+		if (event.isTrusted) {
+			event.preventDefault();
+			window.open(event.currentTarget.dataset.url);
+		}
+	}],
+	[FUNCS.ui.hide, ({ currentTarget }) => {
+		$(currentTarget.dataset.selector).forEach(el => el.hidden = true);
+	}],
+	[FUNCS.ui.unhide, ({ currentTarget }) => {
+		$(currentTarget.dataset.selector).forEach(el => el.hidden = false);
+	}],
+	[FUNCS.ui.disable, ({ currentTarget }) => {
+		$(currentTarget.dataset.selector).forEach(el => el.disabled = true);
+	}],
+	[FUNCS.ui.enable, ({ currentTarget }) => {
+		$(currentTarget.dataset.selector).forEach(el => el.disabled = false);
+	}],
+	[FUNCS.ui.remove, ({ currentTarget }) => {
+		$(currentTarget.dataset.selector).forEach(el => el.remove());
+	}],
+	[FUNCS.ui.scrollTo, ({ currentTarget }) => {
+		const target = document.querySelector(currentTarget.dataset.selector);
 
+		if (target instanceof Element) {
+			target.scrollIntoView({
+				behavor: matchMedia('(prefers-reduced-motion: reduce)').matches
+					? 'instant'
+					: 'smooth',
+			});
+		}
+	}],
+	[FUNCS.ui.showModal, ({ currentTarget }) => {
+		const target = document.querySelector(currentTarget.dataset.selector);
+
+		if (target instanceof HTMLDialogElement) {
+			target.showModal();
+		}
+	}],
+	[FUNCS.ui.closeModal, ({ currentTarget }) => {
+		const target = document.querySelector(currentTarget.dataset.selector);
+
+		if (target instanceof HTMLDialogElement) {
+			target.close();
+		}
+	}],
+	[FUNCS.ui.showPopover, ({ currentTarget }) => {
+		const target = document.querySelector(currentTarget.dataset.selector);
+
+		if (target instanceof HTMLElement) {
+			target.showPopover();
+		}
+	}],
+	[FUNCS.ui.hidePopover, ({ currentTarget }) => {
+		const target = document.querySelector(currentTarget.dataset.selector);
+
+		if (target instanceof HTMLElement) {
+			target.hidePopover();
+		}
+	}],
+	[FUNCS.ui.togglePopover, ({ currentTarget }) => {
+		const target = document.querySelector(currentTarget.dataset.selector);
+
+		if (target instanceof HTMLElement) {
+			target.togglePopover();
+		}
+	}],
+	[FUNCS.ui.print, () => globalThis.print()],
+]);
 
 export const listCallbacks = () => Array.from(handlers.keys());
 

--- a/componentRegistry.js
+++ b/componentRegistry.js
@@ -17,3 +17,9 @@ export function getRegisteredComponentTags() {
 export function getRegisteredComponents() {
 	return Object.freeze(Array.from(registry, tag => customElements.get(tag)));
 }
+
+export function getAttributes(tag) {
+	const constructor = customElements.get(tag);
+
+	return constructor instanceof Function ? constructor.observedAttributes() : [];
+}

--- a/core.js
+++ b/core.js
@@ -4,7 +4,7 @@
 
 export { sanitizerConfig } from './sanitizerConfig.js';
 
-export { attachListeners, AEGIS_EVENT_HANDLER_CLASS, EVENTS } from './events.js';
+export { attachListeners, EVENTS } from './events.js';
 
 export {
 	hasCallback, getCallback, listCallbacks, callCallback, createCallback,
@@ -23,7 +23,7 @@ export {
 	createScript, createScriptURL, createPolicy, getDefaultPolicy,
 } from './trust.js';
 
-export { DATE_FORMAT, formatDate, stringify } from './stringify.js';
+export { DATE_FORMAT, formatDate, stringify, data, attr } from './stringify.js';
 
 export { getUniqueSelector, replaceStyles, addStyles, appendTo, prependTo, replace } from './dom.js';
 

--- a/events.js
+++ b/events.js
@@ -1,43 +1,144 @@
-import { eventAttrs, EVENT_PREFIX_LENGTH } from './sanitizerConfig.js';
 import { hasCallback, getCallback } from './callbackRegistry.js';
 
-export const AEGIS_EVENT_HANDLER_CLASS = '_aegis-event-handler';
+const EVENT_PREFIX =  'data-aegis-event-on-';
+const EVENT_PREFIX_LENGTH = EVENT_PREFIX.length;
+const DATA_PREFIX = 'aegisEventOn';
+const DATA_PREFIX_LENGTH = DATA_PREFIX.length;
+
+const eventAttrs = [
+	EVENT_PREFIX + 'abort',
+	EVENT_PREFIX + 'blur',
+	EVENT_PREFIX + 'focus',
+	EVENT_PREFIX + 'cancel',
+	EVENT_PREFIX + 'auxclick',
+	EVENT_PREFIX + 'beforeinput',
+	EVENT_PREFIX + 'beforetoggle',
+	EVENT_PREFIX + 'canplay',
+	EVENT_PREFIX + 'canplaythrough',
+	EVENT_PREFIX + 'change',
+	EVENT_PREFIX + 'click',
+	EVENT_PREFIX + 'close',
+	EVENT_PREFIX + 'contextmenu',
+	EVENT_PREFIX + 'copy',
+	EVENT_PREFIX + 'cuechange',
+	EVENT_PREFIX + 'cut',
+	EVENT_PREFIX + 'dblclick',
+	EVENT_PREFIX + 'drag',
+	EVENT_PREFIX + 'dragend',
+	EVENT_PREFIX + 'dragenter',
+	EVENT_PREFIX + 'dragexit',
+	EVENT_PREFIX + 'dragleave',
+	EVENT_PREFIX + 'dragover',
+	EVENT_PREFIX + 'dragstart',
+	EVENT_PREFIX + 'drop',
+	EVENT_PREFIX + 'durationchange',
+	EVENT_PREFIX + 'emptied',
+	EVENT_PREFIX + 'ended',
+	EVENT_PREFIX + 'formdata',
+	EVENT_PREFIX + 'input',
+	EVENT_PREFIX + 'invalid',
+	EVENT_PREFIX + 'keydown',
+	EVENT_PREFIX + 'keypress',
+	EVENT_PREFIX + 'keyup',
+	EVENT_PREFIX + 'load',
+	EVENT_PREFIX + 'loadeddata',
+	EVENT_PREFIX + 'loadedmetadata',
+	EVENT_PREFIX + 'loadstart',
+	EVENT_PREFIX + 'mousedown',
+	EVENT_PREFIX + 'mouseenter',
+	EVENT_PREFIX + 'mouseleave',
+	EVENT_PREFIX + 'mousemove',
+	EVENT_PREFIX + 'mouseout',
+	EVENT_PREFIX + 'mouseover',
+	EVENT_PREFIX + 'mouseup',
+	EVENT_PREFIX + 'wheel',
+	EVENT_PREFIX + 'paste',
+	EVENT_PREFIX + 'pause',
+	EVENT_PREFIX + 'play',
+	EVENT_PREFIX + 'playing',
+	EVENT_PREFIX + 'progress',
+	EVENT_PREFIX + 'ratechange',
+	EVENT_PREFIX + 'reset',
+	EVENT_PREFIX + 'resize',
+	EVENT_PREFIX + 'scroll',
+	EVENT_PREFIX + 'scrollend',
+	EVENT_PREFIX + 'securitypolicyviolation',
+	EVENT_PREFIX + 'seeked',
+	EVENT_PREFIX + 'seeking',
+	EVENT_PREFIX + 'select',
+	EVENT_PREFIX + 'slotchange',
+	EVENT_PREFIX + 'stalled',
+	EVENT_PREFIX + 'submit',
+	EVENT_PREFIX + 'suspend',
+	EVENT_PREFIX + 'timeupdate',
+	EVENT_PREFIX + 'volumechange',
+	EVENT_PREFIX + 'waiting',
+	EVENT_PREFIX + 'selectstart',
+	EVENT_PREFIX + 'selectionchange',
+	EVENT_PREFIX + 'toggle',
+	EVENT_PREFIX + 'pointercancel',
+	EVENT_PREFIX + 'pointerdown',
+	EVENT_PREFIX + 'pointerup',
+	EVENT_PREFIX + 'pointermove',
+	EVENT_PREFIX + 'pointerout',
+	EVENT_PREFIX + 'pointerover',
+	EVENT_PREFIX + 'pointerenter',
+	EVENT_PREFIX + 'pointerleave',
+	EVENT_PREFIX + 'gotpointercapture',
+	EVENT_PREFIX + 'lostpointercapture',
+	EVENT_PREFIX + 'mozfullscreenchange',
+	EVENT_PREFIX + 'mozfullscreenerror',
+	EVENT_PREFIX + 'animationcancel',
+	EVENT_PREFIX + 'animationend',
+	EVENT_PREFIX + 'animationiteration',
+	EVENT_PREFIX + 'animationstart',
+	EVENT_PREFIX + 'transitioncancel',
+	EVENT_PREFIX + 'transitionend',
+	EVENT_PREFIX + 'transitionrun',
+	EVENT_PREFIX + 'transitionstart',
+	EVENT_PREFIX + 'webkitanimationend',
+	EVENT_PREFIX + 'webkitanimationiteration',
+	EVENT_PREFIX + 'webkitanimationstart',
+	EVENT_PREFIX + 'webkittransitionend',
+	EVENT_PREFIX + 'error',
+];
+
 const selector = eventAttrs.map(attr => `[${CSS.escape(attr)}]`).join(', ');
 
-export const EVENTS = Object.fromEntries(eventAttrs.map(attr => [
-	`on${attr[EVENT_PREFIX_LENGTH].toUpperCase() + attr.substring(EVENT_PREFIX_LENGTH + 1)}`,
+const DATA_EVENTS = Object.fromEntries([...eventAttrs].map(attr => [
+	`on${attr[EVENT_PREFIX_LENGTH].toUpperCase()}${attr.substring(EVENT_PREFIX_LENGTH + 1)}`,
 	attr
 ]));
 
+export const EVENTS = {
+	...DATA_EVENTS,
+	once: 'data-aegis-event-once',
+	passive: 'data-aegis-event-passive',
+	capture: 'data-aegis-event-capture',
+};
+
+const isEventDataAttr = ([name]) => name.substring(0, DATA_PREFIX_LENGTH) === DATA_PREFIX;
+
 export function attachListeners(target, { signal } = {}) {
 	target.querySelectorAll(selector).forEach(el => {
-		for (const attr of el.getAttributeNames().filter(name => eventAttrs.includes(name))) {
-			const val = el.getAttribute(attr);
+		const dataset = el.dataset;
 
+		for (const [attr, val] of Object.entries(dataset).filter(isEventDataAttr)) {
 			try {
-				if (typeof val === 'string' && val.length !== 0 && hasCallback(val)) {
-					const event = attr.substring(EVENT_PREFIX_LENGTH).trim();
-					const callback = getCallback(val);
-					const passive = el.hasAttribute('aegis:event:passive');
-					const capture = el.hasAttribute('aegis:event:capture');
-					const once = el.hasAttribute('aegis:event:once');
-					el.addEventListener(event, callback, { passive, capture, once, signal });
-				} else {
-					console.warn(`No handler registered for ${val}`);
+				const event = 'on' + attr.substring(DATA_PREFIX_LENGTH);
+
+				if (EVENTS.hasOwnProperty(event) && hasCallback(val)) {
+					el.addEventListener(event.substring(2).toLowerCase(), getCallback(val), {
+						passive: dataset.hasOwnProperty('aegisEventPassive'),
+						capture: dataset.hasOwnProperty('aegisEventCapture'),
+						once: dataset.hasOwnProperty('aegisEventOnce'),
+						signal,
+					});
+
+					el.removeAttribute('data-' + attr.replaceAll(/[A-Z]/g, c => '-' + c).toLowerCase());
 				}
 			} catch(err) {
 				console.error(err);
-			} finally {
-				el.removeAttribute(attr);
-				el.removeAttribute('aegis:event:passive');
-				el.removeAttribute('aegis:event:capture');
-				el.removeAttribute('aegis:event:once');
-
-				if (el.classList.length === 1) {
-					el.removeAttribute('class');
-				} else {
-					el.classList.remove(AEGIS_EVENT_HANDLER_CLASS);
-				}
 			}
 		}
 	});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A fast, secure, modern, light-weight, and simple JS library for creating web components and more!",
   "keywords": [
     "aegis",

--- a/sanitizerConfig.js
+++ b/sanitizerConfig.js
@@ -3,46 +3,6 @@
  * @see https://wicg.github.io/sanitizer-api/#default-configuration-dictionary
  */
 
-export const EVENT_PREFIX =  'aegis:';
-export const EVENT_PREFIX_LENGTH = EVENT_PREFIX.length;
-
-export const eventAttrs = [
-	EVENT_PREFIX + 'abort', EVENT_PREFIX + 'blur', EVENT_PREFIX + 'focus',
-	EVENT_PREFIX + 'cancel', EVENT_PREFIX + 'auxclick', EVENT_PREFIX + 'beforeinput',
-	EVENT_PREFIX + 'beforetoggle', EVENT_PREFIX + 'canplay', EVENT_PREFIX + 'canplaythrough',
-	EVENT_PREFIX + 'change', EVENT_PREFIX + 'click', EVENT_PREFIX + 'close',
-	EVENT_PREFIX + 'contextmenu', EVENT_PREFIX + 'copy',  EVENT_PREFIX + 'cuechange',
-	EVENT_PREFIX + 'cut', EVENT_PREFIX + 'dblclick', EVENT_PREFIX + 'drag',
-	EVENT_PREFIX + 'dragend', EVENT_PREFIX + 'dragenter', EVENT_PREFIX + 'dragexit',
-	EVENT_PREFIX + 'dragleave', EVENT_PREFIX + 'dragover', EVENT_PREFIX + 'dragstart',
-	EVENT_PREFIX + 'drop', EVENT_PREFIX + 'durationchange', EVENT_PREFIX + 'emptied',
-	EVENT_PREFIX + 'ended', EVENT_PREFIX + 'formdata', EVENT_PREFIX + 'input',
-	EVENT_PREFIX + 'invalid', EVENT_PREFIX + 'keydown', EVENT_PREFIX + 'keypress',
-	EVENT_PREFIX + 'keyup', EVENT_PREFIX + 'load', EVENT_PREFIX + 'loadeddata',
-	EVENT_PREFIX + 'loadedmetadata', EVENT_PREFIX + 'loadstart', EVENT_PREFIX + 'mousedown',
-	EVENT_PREFIX + 'mouseenter', EVENT_PREFIX + 'mouseleave', EVENT_PREFIX + 'mousemove',
-	EVENT_PREFIX + 'mouseout', EVENT_PREFIX + 'mouseover', EVENT_PREFIX + 'mouseup',
-	EVENT_PREFIX + 'wheel', EVENT_PREFIX + 'paste', EVENT_PREFIX + 'pause',
-	EVENT_PREFIX + 'play', EVENT_PREFIX + 'playing', EVENT_PREFIX + 'progress',
-	EVENT_PREFIX + 'ratechange', EVENT_PREFIX + 'reset', EVENT_PREFIX + 'resize',
-	EVENT_PREFIX + 'scroll', EVENT_PREFIX + 'scrollend', EVENT_PREFIX + 'securitypolicyviolation',
-	EVENT_PREFIX + 'seeked', EVENT_PREFIX + 'seeking', EVENT_PREFIX + 'select',
-	EVENT_PREFIX + 'slotchange', EVENT_PREFIX + 'stalled', EVENT_PREFIX + 'submit',
-	EVENT_PREFIX + 'suspend', EVENT_PREFIX + 'timeupdate', EVENT_PREFIX + 'volumechange',
-	EVENT_PREFIX + 'waiting', EVENT_PREFIX + 'selectstart', EVENT_PREFIX + 'selectionchange',
-	EVENT_PREFIX + 'toggle', EVENT_PREFIX + 'pointercancel', EVENT_PREFIX + 'pointerdown',
-	EVENT_PREFIX + 'pointerup',  EVENT_PREFIX + 'pointermove', EVENT_PREFIX + 'pointerout',
-	EVENT_PREFIX + 'pointerover', EVENT_PREFIX + 'pointerenter', EVENT_PREFIX + 'pointerleave',
-	EVENT_PREFIX + 'gotpointercapture', EVENT_PREFIX + 'lostpointercapture',
-	EVENT_PREFIX + 'mozfullscreenchange', EVENT_PREFIX + 'mozfullscreenerror',
-	EVENT_PREFIX + 'animationcancel', EVENT_PREFIX + 'animationend', EVENT_PREFIX + 'animationiteration',
-	EVENT_PREFIX + 'animationstart', EVENT_PREFIX + 'transitioncancel',
-	EVENT_PREFIX + 'transitionend', EVENT_PREFIX + 'transitionrun', EVENT_PREFIX + 'transitionstart',
-	EVENT_PREFIX + 'webkitanimationend', EVENT_PREFIX + 'webkitanimationiteration',
-	EVENT_PREFIX + 'webkitanimationstart', EVENT_PREFIX + 'webkittransitionend',
-	EVENT_PREFIX + 'error',
-];
-
 export const allowCustomElements = true;
 export const allowUnknownMarkup = false;
 export const allowComments = false;
@@ -212,6 +172,9 @@ export const allowAttributes = {
 	'placeholder': ['*'],
 	'playsinline': ['*'],
 	'policy': ['*'],
+	'popover': ['*'],
+	'popovertarget': ['*'],
+	'poopovertargetaction': ['*'],
 	'poster': ['*'],
 	'preload': ['*'],
 	'pseudo': ['*'],
@@ -273,10 +236,6 @@ export const allowAttributes = {
 	'webkitdirectory': ['*'],
 	'width': ['*'],
 	'wrap': ['*'],
-	'aegis:event:capture': ['*'],
-	'aegis:event:passive': ['*'],
-	'aegis:event:once': ['*'],
-	...Object.fromEntries(eventAttrs.map(attr => [attr, ['*']]))
 };
 
 export const sanitizerConfig = {

--- a/test/index.html
+++ b/test/index.html
@@ -26,15 +26,17 @@
 				}
 			}
 		</script>
-		<script type="application/javascript" defer="" referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha384-Shkrmxly5RI9mCU8DQr6l4VLVJzjPzgx9KP/f5i7pEcl7ZUt0wHiAweGjbpjU2d5" src="https://unpkg.com/@shgysk8zer0/polyfills@0.3.1/all.min.js" fetchpriority="auto"></script>
+		<script type="application/javascript" defer="" referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha384-da+idpfYh2JjIk81mlgAuhkV0bSAuVW1TA9XLcjht0WOsiSQgwi+uzPM4a2t6A9i" src="https://unpkg.com/@shgysk8zer0/polyfills@0.3.2/all.min.js" fetchpriority="auto"></script>
 		<script type="application/javascript" defer="" referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha384-55L/wO9o0uIVTeubRIDQB4bewfNqyxrj4OXuxlW24NMEk+ioZwMHVw/tFV78mM+k" src="https://unpkg.com/@shgysk8zer0/kazoo@0.3.1/harden.js" fetchpriority="auto"></script>
 		<script type="module" referrerpolicy="no-referrer" src="./index.js"></script>
 	</head>
 	<body>
 		<template id="tmp">
-			<dad-joke></dad-joke>
-			<p>Lorem Ipsum and all that...</p>
-			Free text...
+			<div class="container">
+				<dad-joke></dad-joke>
+				<p>Lorem Ipsum and all that...</p>
+				Free text...
+			</div>
 		</template>
 	</body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import {
 	html, css, replaceStyles, getUniqueSelector, createPolicy, appendTo,
-	createCallback, EVENTS, FUNCS,
+	EVENTS, FUNCS, attr,
 } from '@aegisjsproject/core';
 import { reset } from '@aegisjsproject/styles/reset.js';
 import { baseTheme, lightTheme, darkTheme } from '@aegisjsproject/styles/theme.js';
@@ -46,14 +46,34 @@ appendTo(document.body, html`
 	${trustedTypes.defaultPolicy.createHTML('<hr />')}
 	${new DadJoke()}
 	<div class="flex row wrap btn-container">
-		<a href="./#foo" ${EVENTS.onClick}="${FUNCS.navigate.link}" class="btn btn-primary">Link</a>
-		<button type="button" ${EVENTS.onClick}="${createCallback(() => alert('Testing!'))}" class="btn btn-primary">TEST</button>
-		<button type="button" ${EVENTS.onClick}="${FUNCS.debug.log}" data-foo="bar" class="btn btn-primary">Log</button>
-		<button type="button" ${EVENTS.onClick}="${FUNCS.navigate.back}" class="btn  btn-primary">Back</button>
-		<button type="button" ${EVENTS.onClick}="${FUNCS.navigate.forward}" class="btn  btn-primary">Forward</button>
+		<button data-url="./#foo" ${EVENTS.onClick}="${FUNCS.navigate.link}" class="btn btn-primary">Link</button>
+		<button data-url="https://github.com/AegisJSProject/core/" ${EVENTS.onClick}="${FUNCS.navigate.popup}" class="btn btn-primary">Repo</button>
+		<button type="button" ${EVENTS.onClick}="${() => alert('Testing!')}" class="btn btn-primary">TEST</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.debug.log}" data-foo="bar" class="btn btn-primary" ${attr({ disabled: ! navigator.onLine, lang: navigator.language })}>Log</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.navigate.back}" class="btn btn-primary">Back</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.navigate.forward}" class="btn btn-primary">Forward</button>
 		<button type="button" ${EVENTS.onClick}="${FUNCS.navigate.reload}" class="btn btn-primary">Reload</button>
-		<button type="button" ${EVENTS.onClick}="${FUNCS.print}" class="btn btn-primary">Print</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.print}" class="btn btn-primary">Print</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.remove}" data-selector="header" id="remove-btn" class="btn btn-primary">Remove Header</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.disable}" data-selector="#remove-btn" class="btn btn-primary">Disable Remove Btn</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.enable}" data-selector="#remove-btn" class="btn btn-primary">Enable Remove Btn</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.hide}" data-selector="header" class="btn btn-primary">Hide Header</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.unhide}" data-selector="header" class="btn btn-primary">Show Header</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.showModal}" data-selector="#test-dialog" class="btn btn-primary">Show Modal</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.showPopover}" data-selector="#popover" class="btn btn-primary">Show Popover</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.hidePopover}" data-selector="#popover" class="btn btn-primary">Hide Popover</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.togglePopover}" data-selector="#popover" class="btn btn-primary">Toggle Popover</button>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.scrollTo}" data-selector="#footer" class="btn btn-primary">Scroll To Footer</button>
 	</div>
-	${document.getElementById('tmp')}
-	${css`.btn {font-size: 1.2em;}`}
+	<main id="main">${document.getElementById('tmp')}</main>
+	${css`.btn {font-size: 1.2em;} #main {min-height: 80vh}`}
+	<dialog id="test-dialog">
+		<p>A Test Dialog</p>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.closeModal}" data-selector="#test-dialog">Close</button>
+	</dialog>
+	<div id="popover" popover="manual">
+		<p>A popover</a>
+		<button type="button" ${EVENTS.onClick}="${FUNCS.ui.hidePopover}" data-selector="#popover">Close</button>
+	</div>
+	<footer id="footer">This is the footer</footer>
 `);


### PR DESCRIPTION
**Added**
- Handle wider variety of objects (such as `HTMLTemplateElement` and
`NodeList`, and even functions) in `stringify()`
- Allow attributes for the [Popover
API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
- Add more built-in callbacks to the callback registry
- Add function to get registered component observed attributes by tag
name

**Changed**
- Refactor event handling
- Do not remove other attributes when adding event listeners from
callback registry
- Update Polyfills version (allowing `data-*` attributes)

**Removed**
- Remove `AEGIS_EVENT_HANDLER_CLASS`

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
