### PR TITLE
Add new HTML parser options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.2.23] - 2025-04-08
 
+## [v0.2.24] - 2025-04-17
+
+### Added
+- Add parser for web component/shadow DOM
+
+### Changed
+- `createTrustedHTMLTemplate` now throws if not given a `TrustedTypePolicy`
+
 ### Added
 - Add `createTrustedHTMLTemplate()` to create trusted HTML generating tagged templates
 

--- a/core.js
+++ b/core.js
@@ -14,8 +14,9 @@ export {
 
 export {
 	text, createStyleSheet, createCSSParser, css, lightCSS, darkCSS ,
-	styleSheetToFile, styleSheetToLink, createHTMLParser, html, doc,
+	styleSheetToFile, styleSheetToLink, createHTMLParser, html, doc, trustedHTML,
 	htmlUnsafe, docUnsafe, htmlToFile, createTrustedHTMLTemplate, xml, svg, json, math, url,
+	createShadowParser, shadow, el,
 } from './parsers.js';
 
 export {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/core",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/core",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/core",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "A fast, secure, modern, light-weight, and simple JS library for creating web components and more!",
   "keywords": [
     "aegis",

--- a/parsers.js
+++ b/parsers.js
@@ -3,7 +3,10 @@ export {
 	createStyleSheet, createCSSParser, css, lightCSS,
 	darkCSS, styleSheetToFile, styleSheetToLink,
 } from './parsers/css.js';
-export { createHTMLParser, html, doc, htmlUnsafe, docUnsafe, htmlToFile, createTrustedHTMLTemplate } from './parsers/html.js';
+export {
+	createHTMLParser, html, doc, htmlUnsafe, docUnsafe, htmlToFile,
+	createTrustedHTMLTemplate, trustedHTML, createShadowParser, shadow, el,
+} from './parsers/html.js';
 export { xml } from './parsers/xml.js';
 export { svg } from './parsers/svg.js';
 export { json } from './parsers/json.js';


### PR DESCRIPTION
### Added
- Add parser for web component/shadow DOM

### Changed
- `createTrustedHTMLTemplate` now throws if not given a `TrustedTypePolicy`

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
